### PR TITLE
Use module name remapping for react-next

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
       "jsx",
       "js"
     ],
+    "moduleNameMapper": {
+      "^react$": "gatsby-plugin-react-next/node_modules/react",
+      "^react-dom$": "gatsby-plugin-react-next/node_modules/react-dom"
+    },
     "collectCoverage": true,
     "coverageReporters": [
       "lcov",


### PR DESCRIPTION
In order to update to the latest module versions, you must make sure that jest is pointing to
the correct version of react. Otherwise the enzyme-adapter-react-16 module will attempt
to interact with the react 15.x version that is installed by gatsby.

Otherwise you end up with errors similar to this:
```
Uncaught TypeError: Cannot read property 'ReactCurrentOwner' of undefined
```