### PR TITLE
Add parse-filepath as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "gatsby-transformer-sharp": "^2.1.10",
     "gatsby-transformer-yaml": "^2.1.7",
     "normalize.css": "^8.0.1",
+    "parse-filepath": "1.0.2",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",


### PR DESCRIPTION
I've encountered the following error when trying to start this gatsby starter:
```
$ gatsby develop
success open and validate gatsby-configs - 0.239 s

 ERROR

Error in "gatsby-starter-gatsbythemes/gatsby-node.js": Cannot find module 'parse-filepath'



  Error: Cannot find module 'parse-filepath'
```

After I installed the missing module in question via `npm install`, I can view localhost:8000 via the `gatsby develop` command.